### PR TITLE
Updated Ansible role for percona MYSQL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,21 +1,32 @@
 ---
-# Set this to `true` to forcibly update the root password.
+# ===============================
+# MySQL Root Configuration
+# ===============================
+mysql_root_password: "N0Tweak$_@123!"
 mysql_root_password_update: false
 
-# MySQL connection settings.
+# ===============================
+# Connection Settings
+# ===============================
 mysql_port: "3306"
-mysql_bind_address: '0.0.0.0'
+mysql_bind_address: "0.0.0.0"
 mysql_skip_name_resolve: false
 mysql_datadir: /var/lib/mysql
-mysql_sql_mode: 'STRICT_ALL_TABLES'
+mysql_sql_mode: "STRICT_ALL_TABLES"
 
-# Slow query log settings.
+# Socket (CRITICAL for automation)
+mysql_login_unix_socket: /var/run/mysqld/mysqld.sock
+
+# ===============================
+# Slow Query Log
+# ===============================
 mysql_slow_query_log_enabled: true
 mysql_slow_query_time: "2"
-# The following variable has a default value depending on operating system.
 mysql_slow_query_log_file: /var/log/mysql-slow.log
 
-# Memory settings (default values optimized for ~512MB RAM).
+# ===============================
+# Memory Settings
+# ===============================
 mysql_key_buffer_size: "256M"
 mysql_max_allowed_packet: "64M"
 mysql_table_open_cache: "256"
@@ -33,85 +44,85 @@ mysql_max_heap_table_size: "16M"
 mysql_group_concat_max_len: "1024"
 mysql_join_buffer_size: "262144"
 
-# Other settings.
+# ===============================
+# Other Settings
+# ===============================
 mysql_lower_case_table_names: "0"
 mysql_wait_timeout: "28800"
 mysql_event_scheduler_state: "OFF"
 
-# InnoDB settings.
+# ===============================
+# InnoDB Settings
+# ===============================
 mysql_innodb_file_per_table: "1"
-# Set .._buffer_pool_size up to 80% of RAM but beware of setting too high.
 mysql_innodb_buffer_pool_size: "256M"
-# Set .._log_file_size to 25% of buffer pool size.
 mysql_innodb_log_file_size: "64M"
 mysql_innodb_log_buffer_size: "8M"
 mysql_innodb_flush_log_at_trx_commit: "1"
 mysql_innodb_lock_wait_timeout: "50"
-
-# These settings require MySQL > 5.5.
 mysql_innodb_large_prefix: "1"
 mysql_innodb_file_format: "barracuda"
 
-# mysqldump settings.
+# ===============================
+# mysqldump
+# ===============================
 mysql_mysqldump_max_allowed_packet: "64M"
 
-# Logging settings.
-mysql_log: ""
-# The following variables have a default value depending on operating system.
-# mysql_log_error: /var/log/mysql/mysql.err
-# mysql_syslog_tag: mysql
+# ===============================
+# Logging
+# ===============================
+mysql_log: false
 
+# ===============================
+# Config Includes
+# ===============================
 mysql_config_include_files: []
-#  - src: path/relative/to/playbook/file.cnf
-#  - { src: path/relative/to/playbook/anotherfile.cnf, force: yes }
-
-# Directory for additional MySQL config fragments (used with mysql_config_include_files).
 mysql_config_include_dir: /etc/mysql/conf.d
 
-## Databases.
-# Override in group_vars / host_vars. Left empty to avoid accidental creation.
+# ===============================
+# Databases
+# ===============================
 mysql_databases: []
-#  - name: myapp_db
-#    collation: utf8_general_ci
-#    encoding: utf8
-#    replicate: 1
+# Example:
+# - name: myapp_db
+#   collation: utf8_general_ci
+#   encoding: utf8
 
-# Users.
-# Override in group_vars / host_vars. Passwords should come from Ansible Vault.
+# ===============================
+# Users
+# ===============================
 mysql_users:
- - name: mysqld_exporter
-   host: "localhost"
-   password: "VaultThis@Password!123"
-   priv: "*.*:PROCESS,REPLICATION CLIENT,SELECT"
-#  - name: myapp_user
-#    host: "localhost"
-#    password: "VaultThis@Password!123"
-#    priv: "myapp_db.*:ALL"
+  - name: mysqld_exporter
+    host: "%"
+    password: "VaultThis@Password!123"
+    priv: "*.*:PROCESS,REPLICATION CLIENT,SELECT"
 
-# MySQL root credentials.
-# IMPORTANT: Override this via Ansible Vault in group_vars/host_vars!
-mysql_root_password: "N0Tweak$_@123!"
-
-# Replication settings (replication is only enabled if replication: true).
+# ===============================
+# Replication
+# ===============================
 mysql_server_id: "1"
 mysql_max_binlog_size: "100M"
-mysql_binlog_format: "MIXED"
-mysql_expire_logs_days: "10"
+mysql_binlog_format: "ROW"
+mysql_expire_logs_days: "7"
 
-# Replication user credentials.
-# IMPORTANT: Override password via Ansible Vault!
 mysql_replication_user:
   name: slave
   password: "slaveMaster@123!"
 
-# Backup user credentials.
-# IMPORTANT: Override password via Ansible Vault!
+# ===============================
+# Backup
+# ===============================
 mysql_backup_user:
   name: backup
   password: "backUpMaster@123!"
 
-# mysqld_exporter toggle and settings.
+# ===============================
+# mysqld_exporter
+# ===============================
 mysql_metrics_enabled: true
 mysql_exporter_version: "0.15.1"
 mysql_exporter_user: mysqld_exporter
 mysql_exporter_port: 9104
+
+mysql_exporter_db_user: mysqld_exporter
+mysql_exporter_db_password: "VaultThis@Password!123"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,3 +10,9 @@
   ansible.builtin.systemd:
     daemon_reload: true
   listen: Reload systemd
+
+- name: Restart mysqld_exporter
+  ansible.builtin.service:
+    name: mysqld_exporter
+    state: restarted
+

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -16,9 +16,8 @@
     name: "{{ mysql_backup_user.name }}"
     host: "localhost"
     password: "{{ mysql_backup_user.password }}"
-    login_password: "{{ mysql_root_password }}"
-    login_port: "{{ mysql_port }}"
-    priv: '*.*:RELOAD,LOCK TABLES,REPLICATION CLIENT,CREATE TABLESPACE,PROCESS,SUPER,CREATE,INSERT,SELECT'
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
+    priv: "*.*:RELOAD,LOCK TABLES,REPLICATION CLIENT,CREATE TABLESPACE,PROCESS,SUPER,CREATE,INSERT,SELECT"
     state: present
   no_log: true
   when:
@@ -34,11 +33,11 @@
     - mysql_backup_server is defined
     - inventory_hostname in groups['slave']
 
-- name: Copy backup scripts to /usr/local/bin
+- name: Copy backup scripts
   ansible.builtin.copy:
     src: "{{ item }}"
     dest: /usr/local/bin/
-    mode: '0755'
+    mode: "0755"
   loop:
     - backup-mysql.sh
     - extract-mysql.sh
@@ -69,10 +68,7 @@
     - mysql_backup_server is defined
     - inventory_hostname in groups['slave']
 
-# Check if the encryption key already exists before generating a new one.
-# Regenerating the key on every run would make all previously-encrypted backups
-# undecryptable, causing silent, catastrophic data-loss scenarios.
-- name: Check if backup encryption key already exists
+- name: Check if backup encryption key exists
   ansible.builtin.stat:
     path: "{{ mysql_backup_directory }}/encryption_key"
   register: enc_key_stat
@@ -80,7 +76,7 @@
     - mysql_backup_server is defined
     - inventory_hostname in groups['slave']
 
-- name: Generate backup encryption key (only on first run)
+- name: Generate backup encryption key
   ansible.builtin.command: "openssl rand -base64 24"
   register: encryption_key
   changed_when: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,18 +1,50 @@
 ---
 - name: Get MySQL version
-  ansible.builtin.command: 'mysql --version'
+  ansible.builtin.command: "mysql --version"
   register: mysql_cli_version
   changed_when: false
   check_mode: false
 
+# 🔥 Remove conflicting default config FIRST
+- name: Remove default MySQL config (avoid conflicts)
+  ansible.builtin.file:
+    path: /etc/mysql/mysql.conf.d/mysqld.cnf
+    state: absent
+
+# 🔥 Apply our config
 - name: Copy percona global configuration file
   ansible.builtin.template:
     src: mysqld.cnf.j2
-    dest: "{{ mysql_config_file }}"
+    dest: /etc/mysql/my.cnf
     owner: root
     group: root
     mode: "0644"
-  notify: restart_percona
+
+# 🔥 CRITICAL: Restart immediately so config takes effect BEFORE replication
+- name: Restart MySQL immediately after config change
+  ansible.builtin.service:
+    name: "{{ mysql_daemon }}"
+    state: restarted
+
+# 🔥 Verify GTID BEFORE moving forward
+- name: Verify GTID is enabled
+  community.mysql.mysql_query:
+    query: "SHOW VARIABLES LIKE 'gtid_mode';"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
+  register: gtid_check
+
+- name: Debug GTID value
+  ansible.builtin.debug:
+    msg: "GTID mode is {{ gtid_check.query_result[0][0].Value }}"
+
+- name: Fail if GTID is not enabled
+  ansible.builtin.fail:
+    msg: "GTID is still OFF! MySQL config not applied properly."
+  when: gtid_check.query_result[0][0].Value != "ON"
+
+# ===============================
+# Remaining setup
+# ===============================
 
 - name: Create slow query log file
   ansible.builtin.file:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -5,11 +5,28 @@
   changed_when: false
   check_mode: false
 
-# 🔥 Remove conflicting default config FIRST
-- name: Remove default MySQL config (avoid conflicts)
+# 🔥 Remove ALL conflicting configs (IMPORTANT)
+- name: Remove mysql.conf.d directory (avoid overrides)
   ansible.builtin.file:
-    path: /etc/mysql/mysql.conf.d/mysqld.cnf
+    path: /etc/mysql/mysql.conf.d
     state: absent
+
+- name: Remove conf.d directory (avoid overrides)
+  ansible.builtin.file:
+    path: /etc/mysql/conf.d
+    state: absent
+
+# 🔥 Recreate clean directories (optional but safe)
+- name: Recreate mysql config directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - /etc/mysql/mysql.conf.d
+    - /etc/mysql/conf.d
 
 # 🔥 Apply our config
 - name: Copy percona global configuration file
@@ -20,11 +37,18 @@
     group: root
     mode: "0644"
 
-# 🔥 CRITICAL: Restart immediately so config takes effect BEFORE replication
-- name: Restart MySQL immediately after config change
-  ansible.builtin.service:
-    name: "{{ mysql_daemon }}"
-    state: restarted
+# 🔥 HARD restart (important)
+- name: Force restart MySQL
+  ansible.builtin.shell: |
+    systemctl daemon-reexec
+    systemctl restart {{ mysql_daemon }}
+
+# 🔥 Wait until MySQL is ready
+- name: Wait for MySQL to be ready
+  ansible.builtin.wait_for:
+    port: 3306
+    delay: 5
+    timeout: 30
 
 # 🔥 Verify GTID BEFORE moving forward
 - name: Verify GTID is enabled

--- a/tasks/database.yml
+++ b/tasks/database.yml
@@ -1,13 +1,12 @@
 ---
-- name: Ensure MySQL databases are present.
+- name: Ensure MySQL databases are present
   community.mysql.mysql_db:
-    login_password: "{{ mysql_root_password }}"
-    login_port: "{{ mysql_port }}"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
     name: "{{ item.name }}"
     collation: "{{ item.collation | default('utf8_general_ci') }}"
     encoding: "{{ item.encoding | default('utf8') }}"
     state: "{{ item.state | default('present') }}"
-  with_items: "{{ mysql_databases }}"
+  loop: "{{ mysql_databases }}"
   tags:
     - create_database
   when:

--- a/tasks/mysql_metrics.yml
+++ b/tasks/mysql_metrics.yml
@@ -32,6 +32,18 @@
     mode: "0700"
   tags: mysql_metrics
 
+- name: Ensure mysqld_exporter DB user exists on this node
+  community.mysql.mysql_user:
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
+    name: "{{ mysql_exporter_db_user }}"
+    host: "%"
+    password: "{{ mysql_exporter_db_password }}"
+    priv: "*.*:PROCESS,REPLICATION CLIENT,SELECT"
+    plugin: mysql_native_password
+    state: present
+  no_log: true
+  tags: mysql_metrics
+
 - name: Render exporter credentials file
   ansible.builtin.template:
     src: exporter.cnf.j2
@@ -39,6 +51,7 @@
     owner: "{{ mysql_exporter_user }}"
     group: "{{ mysql_exporter_user }}"
     mode: "0600"
+  notify: Restart mysqld_exporter   
   tags: mysql_metrics
 
 - name: Install mysqld_exporter systemd service
@@ -57,12 +70,13 @@
       ExecStart=/usr/local/bin/mysqld_exporter \
         --config.my-cnf=/etc/mysqld_exporter/.my.cnf \
         --web.listen-address=:{{ mysql_exporter_port }}
-
       Restart=always
 
       [Install]
       WantedBy=multi-user.target
-  notify: Reload systemd
+  notify:
+    - Reload systemd daemon
+    - Restart mysqld_exporter
   tags: mysql_metrics
 
 - name: Enable & start mysqld_exporter

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -1,21 +1,19 @@
 ---
-
 - name: Setting facts for master
   ansible.builtin.set_fact:
-    master_address: "{{ hostvars[groups['master'][0]].ipv4_address | default(hostvars[groups['master'][0]]['ansible_default_ipv4']['address']) }}"
+    master_address: "{{ hostvars[groups['master'][0]]['ansible_host'] }}"
 
 - name: Setting facts for slave
   ansible.builtin.set_fact:
-    slave_address: "{{ groups['slave'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list }}"
+    slave_address: "{{ groups['slave'] | map('extract', hostvars, 'ansible_host') | list }}"
 
 - name: Ensure replication user exists on master
   community.mysql.mysql_user:
     name: "{{ mysql_replication_user.name }}"
     host: "{{ item }}"
     password: "{{ mysql_replication_user.password }}"
-    login_password: "{{ mysql_root_password }}"
-    login_port: "{{ mysql_port }}"
-    priv: "{{ mysql_replication_user.priv | default('*.*:REPLICATION SLAVE,REPLICATION CLIENT') }}"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
+    priv: "*.*:REPLICATION SLAVE,REPLICATION CLIENT"
     state: present
   loop: "{{ slave_address }}"
   no_log: true
@@ -26,22 +24,15 @@
 - name: Check slave replication status
   community.mysql.mysql_replication:
     mode: getreplica
-    login_password: "{{ mysql_root_password }}"
-    login_port: "{{ mysql_port }}"
-  failed_when:
-    - slave_status.failed is defined
-    - slave_status.failed
-    - "'unable to connect' in (slave_status.msg | default(''))"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
   register: slave_status
   when:
     - inventory_hostname in groups['slave']
-    - mysql_replication_user.name is defined
 
 - name: Check master replication status
   community.mysql.mysql_replication:
     mode: getprimary
-    login_password: "{{ mysql_root_password }}"
-    login_port: "{{ mysql_port }}"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
   register: master_status
   when:
     - inventory_hostname in groups['master']
@@ -51,31 +42,18 @@
     mode: changeprimary
     primary_host: "{{ master_address }}"
     primary_user: "{{ mysql_replication_user.name }}"
-    primary_port: "{{ mysql_port }}"
-    login_password: "{{ mysql_root_password }}"
-    login_port: "{{ mysql_port }}"
     primary_password: "{{ mysql_replication_user.password }}"
-    primary_log_file: "{{ hostvars[groups['master'][0]].master_status.File }}"
-    primary_log_pos: "{{ hostvars[groups['master'][0]].master_status.Position }}"
+    primary_auto_position: true
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
   no_log: true
-  failed_when:
-    - configure_replica is failed
-    - "'already' not in (configure_replica.msg | default(''))"
   register: configure_replica
   when:
-    - (slave_status.Is_Replica is defined and not slave_status.Is_Replica) or
-      (slave_status.Is_Replica is not defined and slave_status is failed)
     - inventory_hostname in groups['slave']
     - mysql_replication_user.name is defined
-    - mysql_replication_user.password is defined
 
 - name: Start replication
   community.mysql.mysql_replication:
     mode: startreplica
-    login_password: "{{ mysql_root_password }}"
-    login_port: "{{ mysql_port }}"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
   when:
-    - (slave_status.Is_Replica is defined and not slave_status.Is_Replica) or
-      (slave_status.Is_Replica is not defined and slave_status is failed)
     - inventory_hostname in groups['slave']
-    - master_address is defined

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -1,51 +1,42 @@
 ---
-- name: Check MySQL socket login
+- name: Check MySQL socket login (no password)
   ansible.builtin.command: >
-    mysql --protocol=socket -S {{ mysql_socket }} -NBe "SELECT 1"
+    mysql --protocol=socket -S {{ mysql_login_unix_socket }} -NBe "SELECT 1"
   register: mysql_socket_check
   changed_when: false
   failed_when: false
 
+- name: Fail if MySQL is not accessible via socket
+  ansible.builtin.fail:
+    msg: "Cannot connect to MySQL via socket on {{ inventory_hostname }}"
+  when: mysql_socket_check.rc != 0
+
+- name: Ensure root password is set (optional hardening)
+  ansible.builtin.shell: >
+    mysql --protocol=socket -S {{ mysql_login_unix_socket }} -u root -NBe
+    "ALTER USER 'root'@'localhost'
+    IDENTIFIED WITH mysql_native_password BY '{{ mysql_root_password }}';"
+  when: mysql_root_password_update | bool
+  no_log: true
+
 - name: Disallow root login remotely
   community.mysql.mysql_user:
-    name: "{{ mysql_root_username }}"
+    name: root
     host: "%"
     state: absent
-    login_unix_socket: "{{ mysql_socket }}"
-  when: mysql_socket_check.rc == 0
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
 
-- name: Get list of hosts for the anonymous user.
-  ansible.builtin.command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
+- name: Get anonymous MySQL users
+  ansible.builtin.command: >
+    mysql --protocol=socket -S {{ mysql_login_unix_socket }} -NBe
+    "SELECT Host FROM mysql.user WHERE User='';"
   register: mysql_anonymous_hosts
   changed_when: false
-  check_mode: false
-  when: mysql_socket_check.rc == 0
 
-- name: Remove anonymous MySQL users.
-  ansible.builtin.mysql_user:
+- name: Remove anonymous MySQL users
+  community.mysql.mysql_user:
     name: ""
     host: "{{ item }}"
     state: absent
-  with_items: "{{ mysql_anonymous_hosts.stdout_lines | default([]) }}"
-  when: mysql_socket_check.rc == 0
-
-- name: Get list of hosts for the root user
-  ansible.builtin.command: >
-    mysql -NBe
-    "SELECT Host FROM mysql.user
-    WHERE User = '{{ mysql_root_username }}'
-    ORDER BY (Host='localhost') ASC"
-  register: mysql_root_hosts
-  changed_when: false
-  check_mode: false
-  when: mysql_socket_check.rc == 0
-
-- name: Ensure root password is set
-  ansible.builtin.shell: >
-    mysql -u root -NBe
-    'ALTER USER "{{ mysql_root_username }}"@"{{ item }}"
-    IDENTIFIED WITH mysql_native_password BY "{{ mysql_root_password }}";'
-  with_items: "{{ mysql_root_hosts.stdout_lines | default([]) }}"
-  when:
-    - mysql_socket_check.rc == 0
-    - mysql_install_packages | bool or mysql_root_password_update
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
+  loop: "{{ mysql_anonymous_hosts.stdout_lines | default([]) }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,16 +1,15 @@
 ---
-- name: Ensure MySQL users are present.
+- name: Ensure MySQL users are present
   community.mysql.mysql_user:
-    login_password: "{{ mysql_root_password }}"
-    login_port: "{{ mysql_port }}"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
     name: "{{ item.name }}"
-    host: "{{ item.host | default('localhost') }}"
+    host: "{{ item.host | default('%') }}"
     password: "{{ item.password }}"
     priv: "{{ item.priv | default('*.*:USAGE') }}"
     state: "{{ item.state | default('present') }}"
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
-  with_items: "{{ mysql_users }}"
+  loop: "{{ mysql_users }}"
   no_log: true
   tags:
     - create_user

--- a/templates/backup.cnf.j2
+++ b/templates/backup.cnf.j2
@@ -2,4 +2,5 @@
 [client]
 user={{ mysql_backup_user.name }}
 password={{ mysql_backup_user.password }}
+host=127.0.0.1
 port={{ mysql_port }}

--- a/templates/exporter.cnf.j2
+++ b/templates/exporter.cnf.j2
@@ -2,3 +2,5 @@
 [client]
 user={{ mysql_exporter_db_user }}
 password={{ mysql_exporter_db_password }}
+host=127.0.0.1
+port={{ mysql_port }}

--- a/templates/mysqld.cnf.j2
+++ b/templates/mysqld.cnf.j2
@@ -57,6 +57,9 @@ log-bin-index = mysql-bin.index
 expire_logs_days = {{ mysql_expire_logs_days }}
 max_binlog_size = {{ mysql_max_binlog_size }}
 binlog_format = {{ mysql_binlog_format }}
+gtid_mode=ON
+enforce_gtid_consistency=ON
+log_slave_updates=ON
 
 {% for db in mysql_databases %}
 {% if db.replicate | default(1) %}
@@ -69,6 +72,9 @@ binlog_ignore_db = {{ db.name }}
 {% elif inventory_hostname in groups['slave'] | default([]) %}
 # Replication - Replica (Slave)
 server-id = {{ mysql_server_id }}
+gtid_mode=ON
+enforce_gtid_consistency=ON
+log_slave_updates=ON
 read_only
 relay-log = relay-bin
 relay-log-index = relay-bin.index

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,7 +17,7 @@ mysql_root_username: root
 mysql_supports_innodb_large_prefix: true
 mysql_install_packages: true
 
-replication: false
+replication: true
 backup: false
 
 mysql_backup_config_file: /etc/mysql/backup.cnf


### PR DESCRIPTION
- Fully automated MySQL master-slave setup
- GTID-based replication (no manual binlog handling)
- Consistent and repeatable deployments
- Production-ready Ansible role